### PR TITLE
Stats Page

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -23,6 +23,7 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.FetchOptions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -78,5 +79,12 @@ public class Datastore {
     }
 
     return messages;
+  }
+
+  /** Returns the total number of messages for all users. */
+  public int getTotalMessageCount(){
+    Query query = new Query("Message");
+    PreparedQuery results = datastore.prepare(query);
+    return results.countEntities(FetchOptions.Builder.withLimit(1000));
   }
 }

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -1,0 +1,22 @@
+package com.google.codeu.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Responds with a hard-coded message for testing purposes.
+ */
+@WebServlet("/stats")
+public class StatsPageServlet extends HttpServlet{
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+
+        response.getOutputStream().println("hello world");
+    }
+}

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -7,16 +7,35 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.codeu.data.Datastore;
+import com.google.gson.JsonObject;
+
 /**
- * Responds with a hard-coded message for testing purposes.
+ * Handles fetching site statistics.
  */
 @WebServlet("/stats")
 public class StatsPageServlet extends HttpServlet{
 
+    private Datastore datastore;
+
+    @Override
+    public void init() {
+        datastore = new Datastore();
+    }
+
+    /**
+     * Responds with site statistics in JSON.
+     */
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
 
-        response.getOutputStream().println("hello world");
+        response.setContentType("application/json");
+
+        int messageCount = datastore.getTotalMessageCount();
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("messageCount", messageCount);
+        response.getOutputStream().println(jsonObject.toString());
     }
 }


### PR DESCRIPTION
Added the first four steps of the Stats Page. This page simply shows the number of total messages across all users. Navigate to page by running localhost:8080/stats