### PR TITLE
created stats.html page

### DIFF
--- a/src/main/webapp/js/stats-loader.js
+++ b/src/main/webapp/js/stats-loader.js
@@ -1,0 +1,26 @@
+/**Fetch stats and display them in the page.*/
+function fetchStats() {
+    const url = '/stats';
+    fetch(url).then((response) = > {
+        return response.json();
+}).
+    then((stats) = > {
+        const statsContainer = document.getElementById('stats-container');
+    statsContainer.innerHTML = '';
+
+    const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
+    statsContainer.appendChild(messageCountElement);
+})
+    ;
+}
+
+function buildStatElement(statString) {
+    const statElement = document.createElement('p');
+    statElement.appendChild(document.createTextNode(statString));
+    return statElement;
+}
+
+/**Fetch data and populate the UI of the page.*/
+function buildUI() {
+    fetchStats();
+}

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Stats</title>
+    <link rel="stylesheet" href="/css/main.css">
+    <script src="/js/stats-loader.js"></script>
+</head>
+<body onload="buildUI();">
+<div id="content">
+    <h1>Site Statistics</h1>
+    <hr/>
+    <div id="stats-container">Loading...</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Users will be able to see statistics when they navigate to the stats.html page. Users no longer have to read JSON data, but instead can visit a webpage with the statistics. Statistics are fetched through the files stats.html and stats-loader.js. There is currently only one statistic: message count.